### PR TITLE
Add support for libusb callbacks

### DIFF
--- a/examples/hotplug.rs
+++ b/examples/hotplug.rs
@@ -1,0 +1,73 @@
+extern crate libusb_sys as ffi;
+extern crate libc;
+
+use libc::c_int;
+
+use std::mem;
+
+fn main() {
+    let mut context: *mut ::ffi::libusb_context = unsafe { mem::uninitialized() };
+
+    match unsafe { ::ffi::libusb_init(&mut context) } {
+        0 => (),
+        e => panic!("libusb_init: {}", get_error(e))
+    };
+
+    listen_for_events(context)
+        .expect("Couldn't setup listener");
+
+    while unsafe { ::ffi::libusb_handle_events(context) } == 0 {}
+
+    unsafe { ::ffi::libusb_exit(context) };
+}
+
+fn listen_for_events(context: *mut ::ffi::libusb_context) -> Result<(), String> {
+    if ! unsafe { ::ffi::libusb_has_capability(::ffi::LIBUSB_CAP_HAS_HOTPLUG) > 0 } {
+        return Err("Libusb doesn't support hotplug on this platform".into());
+    }
+
+    let res = unsafe { ::ffi::libusb_hotplug_register_callback(
+        context,
+        ::ffi::LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED | ::ffi::LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT,
+        ::ffi::LIBUSB_HOTPLUG_ENUMERATE,
+        ::ffi::LIBUSB_HOTPLUG_MATCH_ANY,
+        ::ffi::LIBUSB_HOTPLUG_MATCH_ANY,
+        ::ffi::LIBUSB_HOTPLUG_MATCH_ANY,
+        callback_fn,
+        0 as *mut ::std::ffi::c_void,
+        0 as *mut i32) };
+    if res != ::ffi::LIBUSB_SUCCESS {
+        return Err("Failed to setup callback".into());
+    }
+
+    return Ok(())
+}
+
+extern "C" fn callback_fn(_ctx: *mut ::ffi::libusb_context, _device: *const ::ffi::libusb_device, event: i32, _data: *mut ::std::ffi::c_void) -> i32 {
+    match event {
+        e if e == ::ffi::LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED => println!("Device attached!"),
+        e if e == ::ffi::LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT =>  println!("Device removed!"),
+        e => println!("Some other event arrived?: {}", e),
+    };
+    0
+}
+
+fn get_error(err: c_int) -> &'static str {
+    match err {
+        ::ffi::LIBUSB_SUCCESS             => "success",
+        ::ffi::LIBUSB_ERROR_IO            => "I/O error",
+        ::ffi::LIBUSB_ERROR_INVALID_PARAM => "invalid parameter",
+        ::ffi::LIBUSB_ERROR_ACCESS        => "access denied",
+        ::ffi::LIBUSB_ERROR_NO_DEVICE     => "no such device",
+        ::ffi::LIBUSB_ERROR_NOT_FOUND     => "entity not found",
+        ::ffi::LIBUSB_ERROR_BUSY          => "resource busy",
+        ::ffi::LIBUSB_ERROR_TIMEOUT       => "opteration timed out",
+        ::ffi::LIBUSB_ERROR_OVERFLOW      => "overflow error",
+        ::ffi::LIBUSB_ERROR_PIPE          => "pipe error",
+        ::ffi::LIBUSB_ERROR_INTERRUPTED   => "system call interrupted",
+        ::ffi::LIBUSB_ERROR_NO_MEM        => "insufficient memory",
+        ::ffi::LIBUSB_ERROR_NOT_SUPPORTED => "operation not supported",
+        ::ffi::LIBUSB_ERROR_OTHER | _     => "other error"
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,9 +192,13 @@ pub struct libusb_pollfd {
     pub events: c_short,
 }
 
+
+pub type libusb_hotplug_callback_handle = c_int;
+
 pub type libusb_transfer_cb_fn = extern "C" fn(*mut libusb_transfer);
 pub type libusb_pollfd_added_cb = extern "C" fn(c_int, c_short, *mut c_void);
 pub type libusb_pollfd_removed_cb = extern "C" fn(c_int, *mut c_void);
+pub type libusb_hotplug_callback_fn = extern "C" fn(*mut libusb_context, *const libusb_device, c_int, *mut c_void) -> c_int;
 
 // libusb_error
 pub const LIBUSB_SUCCESS:             c_int = 0;
@@ -347,7 +351,22 @@ pub const LIBUSB_REQUEST_SET_SEL:           u8 = 0x30;
 pub const LIBUSB_SET_ISOCH_DELAY:           u8 = 0x31;
 
 
+// libusb_hotplug_event
+pub const LIBUSB_HOTPLUG_EVENT_DEVICE_ARRIVED: c_int = 0x01;
+pub const LIBUSB_HOTPLUG_EVENT_DEVICE_LEFT:    c_int = 0x02;
+
+
+// libusb_hotplug_flag
+pub const LIBUSB_HOTPLUG_NO_FLAGS:  c_int = 0;
+pub const LIBUSB_HOTPLUG_ENUMERATE: c_int = 1;
+
+pub const LIBUSB_HOTPLUG_MATCH_ANY: c_int = -1;
+
+
 extern "C" {
+
+
+
     pub fn libusb_get_version() -> *const libusb_version;
     pub fn libusb_has_capability(capability: u32) -> c_int;
     pub fn libusb_error_name(errcode: c_int) -> *const c_char;
@@ -442,6 +461,9 @@ extern "C" {
     pub fn libusb_get_next_timeout(context: *mut libusb_context, tv: *mut timeval) -> c_int;
     pub fn libusb_get_pollfds(context: *mut libusb_context) -> *const *mut libusb_pollfd;
     pub fn libusb_set_pollfd_notifiers(context: *mut libusb_context, added_cb: libusb_pollfd_added_cb, removed_cb: libusb_pollfd_removed_cb, user_data: *mut c_void);
+
+    pub fn libusb_hotplug_register_callback(context: *mut libusb_context, events: c_int, flags: c_int, vendor_id: c_int, product_id: c_int, dev_class: c_int, cb_fn: libusb_hotplug_callback_fn, user_data: *mut c_void, callback_handle: *mut libusb_hotplug_callback_handle) -> c_int;
+    pub fn libusb_hotplug_deregister_callback(context: *mut libusb_context, callback_handle: libusb_hotplug_callback_handle);
 }
 
 


### PR DESCRIPTION
I added these by hand, not with bindgen or anything, so let me know if I did anything wrong. I also wasn't sure if you wanted native enums or c_ints so I went with what was already here.