### PR TITLE
Add libusb_get_descriptor

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,17 @@ pub struct libusb_version {
 
 #[allow(non_snake_case)]
 #[repr(C)]
+pub struct libusb_dfu_func_descriptor {
+    pub bLength: u8,
+    pub bDescriptorType: u8,
+    pub bmAttributes: u8,
+    pub wDetachTimeOut: u16,
+    pub wTransferSize: u16,
+    pub bcdDFUVersion: u16,
+}
+
+#[allow(non_snake_case)]
+#[repr(C)]
 pub struct libusb_device_descriptor {
     pub bLength: u8,
     pub bDescriptorType: u8,
@@ -283,6 +294,7 @@ pub const LIBUSB_DT_ENDPOINT:              u8 = 0x05;
 pub const LIBUSB_DT_BOS:                   u8 = 0x0F;
 pub const LIBUSB_DT_DEVICE_CAPABILITY:     u8 = 0x10;
 pub const LIBUSB_DT_HID:                   u8 = 0x21;
+pub const LIBUSB_DT_DFU:                   u8 = 0x21;
 pub const LIBUSB_DT_REPORT:                u8 = 0x22;
 pub const LIBUSB_DT_PHYSICAL:              u8 = 0x23;
 pub const LIBUSB_DT_HUB:                   u8 = 0x29;
@@ -382,6 +394,7 @@ extern "C" {
     pub fn libusb_ref_device(dev: *mut libusb_device) -> *mut libusb_device;
     pub fn libusb_unref_device(dev: *mut libusb_device);
 
+    pub fn libusb_get_descriptor(dev_handle: *mut libusb_device_handle, desc_type: u8, desc_index: u8, data: *mut c_uchar, length: c_int) -> c_int;
     pub fn libusb_get_device_descriptor(dev: *const libusb_device, desc: *mut libusb_device_descriptor) -> c_int;
     pub fn libusb_get_config_descriptor(dev: *const libusb_device, index: u8, config: *mut *const libusb_config_descriptor) -> c_int;
     pub fn libusb_get_active_config_descriptor(dev: *const libusb_device, config: *mut *const libusb_config_descriptor) -> c_int;


### PR DESCRIPTION
Hello,

I need help. I'm trying to add the function `libusb_get_descriptor` as [documented here](https://libusb.sourceforge.io/api-1.0/group__libusb__desc.html#ga9e34f7ecf3817e9bfe77ed09238940df).

But when I compile my code I'm getting the error `undefined reference to 'libusb_get_descriptor'`: 

<details>
        <summary>Click to expand</summary>

> error: linking with `cc` failed: exit code: 1
  |
  = note: "cc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-m64" "-Wl,--eh-frame-hdr" "-L" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1391o1tk8s31ulc4.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1461g0sl15oo1q7a.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.15fewxh1czkx529v.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.18hu45qsmy6khzhc.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.19tnii7kxcwglpd2.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1bawyxjyu3fkxdne.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1ci6j9lm79wfeux4.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1gg1nmihyxwgvuoh.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1hp7qev6oqblu7at.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1i24dt0mvlx92bda.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1j4jngsf6ia32d2b.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1k5d535kbnhrc913.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1lw3a8yzrm0sopxv.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1nl16za7rtj1m27x.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1uai8c9mcj0qehvc.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1wo7sdwd8n41nhje.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1wvwtilfft4yamum.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.1za07oii2s0kn0qp.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.244b3bjuwbuqs9ll.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.25qnsqrorupm4szj.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.27m2r2i8gcal33zp.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2bfxxc5wgoa523iq.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2ce8ecqxhgswbeyh.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2ecljw0b3f8vf7su.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2esm1t6xche9pz3i.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2fyuhz7d8h3r16o1.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2h5buii9ds14br3l.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2haiih7psj0lri8i.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2ikt2sib2qu5iciu.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2m1p1g9ivo1xyt9k.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2myj6y71os9vphd.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2u05w7vg8g2hw6q9.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2wrvd3yio9j9od4i.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2yc03vxaqvgb8n0f.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.2ymdcxrl87rt3ynv.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.302mwy3qm4dj0wbg.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.304tsdwgoigbodl4.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.333z2fosrdvm8c7k.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.33rvosewaotkgmyh.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.34vqneddf757cj0b.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.34yf72wi1pibccam.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.358381xf3frpi0m1.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.36hp422woy4iy8lc.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.377mwdvbe4fxcrd0.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.384bbxn3v5yzorco.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.38d9q5hkp96bc9t.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.393dehj80cz1h2x0.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3addkj0tn2tq30n.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3auuffhpc0n3999g.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3c817y59gdcztpfs.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3fvzsdi1da83s455.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3jfs03nn3cvfct6b.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3ntq6z3738lcfvzt.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3o8j8hdl64fdj1hx.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3oir6kci8runb4wk.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3ojl1yvjvlf0nl5t.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3r5yaoobch8qto3m.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3row2c21hjyxlbqu.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3saadcd7jbdo2cgm.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3t9iu6t26q4k0xzr.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3we08culwdugw7u0.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3wqhrwodplerarn0.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3wvs920lbxku1o60.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3xixdsqr030ovxtd.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3xm3h8nzv7cyix66.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3xvesc3gacr94z5g.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3ycgx7mig6g7pcky.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.3yi7quvu678dtmxb.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.49sgx8n9n1z1en52.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4aqgja64dfc70xcd.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4ecnajvf0j6i1zl1.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4jewd3s4uxwldq24.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4ogpqmke8wcy5354.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4q0sgovfs3l6ctr6.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4ramwdlt1b8s9xhd.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4z88o3hzeh8qvedj.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.56kl1jicu7q8n3ci.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.56npus5gspcaybyp.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.5bxmqttj7x947jc7.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.5ch0lhly3zr30mjn.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.5dxid8towidcle0p.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.74z5bbolj4hs333.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.7h620jyyswzue0f.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.9mrpuo2imuit95n.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.be0bl7ruxiu9jg2.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.cjcxhdgl20qeki0.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.ckm2am283n24vz8.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.h36d1wr0rw1h1t1.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.h61633eptlypzpp.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.i8dk7hwd1347fc5.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.ij05ixi0kectrdh.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.isvjlghpz1yu8nv.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.o2xwmuw7ssl553j.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.olg18g8jh1lkmux.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.otsxr6jdoj9m9ym.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.v4l0a1mko6j9z12.rcgu.o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.zi1mnm7oas6fn4w.rcgu.o" "-o" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa" "/home/cecile/repos/dfu-core/target/debug/deps/dfu_core-f25e534b416f4aaa.4kcjzmpo89us3nub.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro" "-Wl,-znow" "-nodefaultlibs" "-L" "/home/cecile/repos/dfu-core/target/debug/deps" "-L" "/usr/lib" "-L" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-Wl,-Bstatic" "/home/cecile/repos/dfu-core/target/debug/deps/liblibusb-2ad63a39f1a90392.rlib" "/home/cecile/repos/dfu-core/target/debug/deps/liblibusb_sys-99cd027878d6c801.rlib" "/home/cecile/repos/dfu-core/target/debug/deps/liblibc-4791cf69e6f72291.rlib" "/home/cecile/repos/dfu-core/target/debug/deps/libbit_set-9fc77bed74cfde45.rlib" "/home/cecile/repos/dfu-core/target/debug/deps/libbit_vec-07d84318a3903497.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libtest-43069443d3425670.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libterm-c889a15e9065e34c.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgetopts-6b6603dcef796920.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunicode_width-f67b472b1a93c6dc.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_std-d80ca4636b9650e1.rlib" "/home/cecile/repos/dfu-core/target/debug/deps/libthiserror-5f1166ed274a5130.rlib" "/home/cecile/repos/dfu-core/target/debug/deps/libbytes-9a37c538aa668507.rlib" "-Wl,--start-group" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-627bae978fe79731.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libpanic_unwind-8fd260299546d3ee.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libminiz_oxide-dbf893bf385c7fde.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libadler-3c401610d018fd42.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libobject-cdf83dbfb357ed60.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libaddr2line-fa2e89ff470279bf.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libgimli-827b31e61df5ff91.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_demangle-80bafd0e67844af2.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libhashbrown-fd4580c166a64cb5.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_alloc-eac8469870b4caf2.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libunwind-e4419d54fb5e553e.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcfg_if-6fda7e79717e1249.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liblibc-12014550f4f9e9fe.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/liballoc-f17bff66051ab5b2.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/librustc_std_workspace_core-7a9bbfe108bb639f.rlib" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcore-93d303b7ed185ae0.rlib" "-Wl,--end-group" "/home/cecile/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/x86_64-unknown-linux-gnu/lib/libcompiler_builtins-ea39d51a71f3ca0c.rlib" "-Wl,-Bdynamic" "-lusb-1.0" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc"
  = note: /usr/bin/ld: /home/cecile/repos/dfu-core/target/debug/deps/liblibusb-2ad63a39f1a90392.rlib(libusb-2ad63a39f1a90392.1vnuh0r0s6ukjooq.rcgu.o): in function `libusb::device_handle::DeviceHandle::read_dfu_func_descriptor':
          /home/cecile/repos/libusb-rs/src/device_handle.rs:499: undefined reference to `libusb_get_descriptor'
          collect2: error: ld returned 1 exit status
          

error: aborting due to previous error; 16 warnings emitted

error: could not compile `dfu-core`

To learn more, run the command again with --verbose.
</details>

It is weird because I'm pretty sure the version 1.0.24 is being selected. I even changed the build.rs to enforce it:
```rust
fn main() {
  pkg_config::Config::new().atleast_version("1.0.24").find("libusb-1.0").unwrap();
}
```